### PR TITLE
Make "allowed values" compatible with PyWPS 4.0

### DIFF
--- a/wpslib/processdescription.py
+++ b/wpslib/processdescription.py
@@ -264,8 +264,8 @@ def allowedValues(aValues):
 
        try:
           for n in range(int(min_val), int(max_val) + 1):
-              myVal = pystring()
-              myVal.append(str(n))
+              myVal = pystring(str(n))
+              #myVal.append(str(n))
               valList.append(myVal)
        except:
            QMessageBox.critical(None, QApplication.translate("QgsWps", "Error"), QApplication.translate("QgsWps", "Maximum allowed Value is too large"))


### PR DESCRIPTION
Hello Horst,

I changed two lines in the wps lib regarding the allowed values of a wps literal input. Behavior before has ignored any special restrictions of allowed values. For example using following line of my wps:

allowed_values=[AllowedValue(allowed_type='range', minval=-10, maxval=10)]

I'm using this in my project. (https://gitlab.com/hadlaskard/integration-of-wps-in-local-sdi)

Best regards from Freiburg
Gunnar